### PR TITLE
always build notebooks but only deploy on main

### DIFF
--- a/.github/workflows/deploy-docs-book.yml
+++ b/.github/workflows/deploy-docs-book.yml
@@ -10,15 +10,17 @@ on:
     branches:
     - master
     - main
+    types: [opened, synchronize, reopened, closed]
 
   # Allow manual triggering of the workflow
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
+  pull-requests: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -31,8 +33,10 @@ jobs:
   deploy-book:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pages: write
       id-token: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -44,6 +48,7 @@ jobs:
 
     # Build the book
     - name: Build the book
+      if: github.event.action != 'closed'
       run: |
         # install package with dependencies and editable version of our package
         # so that it is available in the venv
@@ -65,3 +70,11 @@ jobs:
       if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       id: deployment
       uses: actions/deploy-pages@v4
+
+    # Deploy the PR Preview to GitHub Pages
+    # Only run on pull requests. On 'closed' events, it will clean up the preview instead.
+    - name: Deploy PR Preview to GitHub Pages
+      if: github.event_name == 'pull_request'
+      uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: docs/_build/html/

--- a/.github/workflows/deploy-docs-book.yml
+++ b/.github/workflows/deploy-docs-book.yml
@@ -1,8 +1,12 @@
 name: build-docs
 
-# Run this when the master or main branch changes
+# Run this when the master or main branch changes, or on PRs to those branches
 on:
   push:
+    branches:
+    - master
+    - main
+  pull_request:
     branches:
     - master
     - main
@@ -48,12 +52,16 @@ jobs:
         LOGURU_LEVEL=WARNING uv run --all-groups jupyter-book build docs/
 
     # Upload the book's HTML as an artifact
+    # Only run on push (which happens when PRs are merged or direct commits are made to main/master) or manual dispatch
     - name: Upload artifact
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/upload-pages-artifact@v3
       with:
         path: "docs/_build/html"
 
     # Deploy the book's HTML to GitHub Pages
+    # Only run on push (which happens when PRs are merged or direct commits are made to main/master) or manual dispatch
     - name: Deploy to GitHub Pages
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       id: deployment
       uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,3 +1,18 @@
+# ==============================================================================
+# WORKFLOW: Deploy PR Preview
+#
+# WHEN IT RUNS:
+# - Automatically triggered *after* the "docs" workflow completes.
+#
+# WHAT IT DOES:
+# This is the "trusted" part of the PR preview process, allowing us to safely
+# deploy previews for PRs originating from forks without hitting 403 Forbidden errors.
+# 1. Runs in the privileged context of the base repository.
+# 2. Downloads the built HTML and PR metadata artifacts from the "docs" run.
+# 3. If the PR is open/updated: Deploys the preview to the `gh-pages` branch
+#    and posts a comment with the link on the PR.
+# 4. If the PR is closed: Removes the preview folder from the `gh-pages` branch.
+# ==============================================================================
 name: Deploy PR Preview
 
 on:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,60 @@
+name: Deploy PR Preview
+
+on:
+  workflow_run:
+    workflows: ["docs"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download PR Info
+      uses: actions/download-artifact@v4
+      with:
+        name: pr-info
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: pr_info
+
+    - name: Read PR Info
+      id: pr_info
+      run: |
+        echo "pr_number=$(cat pr_info/pr_number.txt)" >> $GITHUB_ENV
+        echo "action=$(cat pr_info/action.txt)" >> $GITHUB_ENV
+
+    - name: Download built docs
+      if: env.action != 'closed' && github.event.workflow_run.conclusion == 'success'
+      uses: actions/download-artifact@v4
+      with:
+        name: built-docs
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: docs/_build/html
+
+    - name: Deploy PR Preview
+      if: env.action != 'closed' && github.event.workflow_run.conclusion == 'success'
+      uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: docs/_build/html/
+        preview-branch: gh-pages
+        pr-id: ${{ env.pr_number }}
+        action: deploy
+
+    - name: Remove PR Preview
+      if: env.action == 'closed'
+      uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: .
+        preview-branch: gh-pages
+        pr-id: ${{ env.pr_number }}
+        action: remove

--- a/.github/workflows/jupyterbook-docs.yml
+++ b/.github/workflows/jupyterbook-docs.yml
@@ -1,4 +1,4 @@
-name: build-docs
+name: docs
 
 # Run this when the master or main branch changes, or on PRs to those branches
 on:

--- a/.github/workflows/jupyterbook-docs.yml
+++ b/.github/workflows/jupyterbook-docs.yml
@@ -28,15 +28,10 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-# This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
-  deploy-book:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-      pull-requests: write
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -48,7 +43,6 @@ jobs:
 
     # Build the book
     - name: Build the book
-      if: github.event.action != 'closed'
       run: |
         # install package with dependencies and editable version of our package
         # so that it is available in the venv
@@ -56,25 +50,61 @@ jobs:
         uv pip install -e .
         LOGURU_LEVEL=WARNING uv run --all-groups jupyter-book build docs/
 
-    # Upload the book's HTML as an artifact
+    # Upload the built HTML so deployment jobs can use it
+    - name: Upload HTML Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: built-docs
+        path: "docs/_build/html"
+        retention-days: 1
+
+  deploy-main:
+    runs-on: ubuntu-latest
+    needs: build
     # Only run on push (which happens when PRs are merged or direct commits are made to main/master) or manual dispatch
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Download HTML Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: built-docs
+        path: "docs/_build/html"
+
+    # Upload the book's HTML as a pages artifact
     - name: Upload artifact
-      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/upload-pages-artifact@v3
       with:
         path: "docs/_build/html"
 
     # Deploy the book's HTML to GitHub Pages
-    # Only run on push (which happens when PRs are merged or direct commits are made to main/master) or manual dispatch
     - name: Deploy to GitHub Pages
-      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       id: deployment
       uses: actions/deploy-pages@v4
 
+  pr-preview:
+    runs-on: ubuntu-latest
+    needs: build
+    # We use always() to ensure this runs even if the 'build' job was skipped (which happens on PR closed events)
+    # We only want to run this if the build succeeded OR if the PR is being closed.
+    if: ${{ always() && github.event_name == 'pull_request' && (needs.build.result == 'success' || github.event.action == 'closed') }}
+    steps:
+    # We need to checkout the code so the preview action can commit to the gh-pages branch
+    - uses: actions/checkout@v4
+
+    # We only download the artifact if the build actually happened (i.e. PR is not closed)
+    - name: Download HTML Artifact
+      if: github.event.action != 'closed'
+      uses: actions/download-artifact@v4
+      with:
+        name: built-docs
+        path: "docs/_build/html"
+
     # Deploy the PR Preview to GitHub Pages
-    # Only run on pull requests. On 'closed' events, it will clean up the preview instead.
+    # On 'closed' events, it will clean up the preview instead of deploying.
     - name: Deploy PR Preview to GitHub Pages
-      if: github.event_name == 'pull_request'
       uses: rossjrw/pr-preview-action@v1
       with:
         source-dir: docs/_build/html/

--- a/.github/workflows/jupyterbook-docs.yml
+++ b/.github/workflows/jupyterbook-docs.yml
@@ -17,10 +17,9 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
-  pull-requests: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -29,6 +28,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  save-pr-info:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - name: Save PR info
+      run: |
+        mkdir -p pr_info
+        echo "${{ github.event.number }}" > pr_info/pr_number.txt
+        echo "${{ github.event.action }}" > pr_info/action.txt
+
+    - name: Upload PR info
+      uses: actions/upload-artifact@v4
+      with:
+        name: pr-info
+        path: pr_info/
+        retention-days: 1
+
   build:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
@@ -83,28 +99,3 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
-
-  pr-preview:
-    runs-on: ubuntu-latest
-    needs: build
-    # We use always() to ensure this runs even if the 'build' job was skipped (which happens on PR closed events)
-    # We only want to run this if the build succeeded OR if the PR is being closed.
-    if: ${{ always() && github.event_name == 'pull_request' && (needs.build.result == 'success' || github.event.action == 'closed') }}
-    steps:
-    # We need to checkout the code so the preview action can commit to the gh-pages branch
-    - uses: actions/checkout@v4
-
-    # We only download the artifact if the build actually happened (i.e. PR is not closed)
-    - name: Download HTML Artifact
-      if: github.event.action != 'closed'
-      uses: actions/download-artifact@v4
-      with:
-        name: built-docs
-        path: "docs/_build/html"
-
-    # Deploy the PR Preview to GitHub Pages
-    # On 'closed' events, it will clean up the preview instead of deploying.
-    - name: Deploy PR Preview to GitHub Pages
-      uses: rossjrw/pr-preview-action@v1
-      with:
-        source-dir: docs/_build/html/

--- a/.github/workflows/jupyterbook-docs.yml
+++ b/.github/workflows/jupyterbook-docs.yml
@@ -1,3 +1,18 @@
+# ==============================================================================
+# WORKFLOW: docs (Build & Main Deploy)
+#
+# WHEN IT RUNS:
+# - On pushes to `main` or `master` branches.
+# - On pull requests targeting `main` or `master` (opened, synchronized, closed).
+# - Manually via workflow_dispatch.
+#
+# WHAT IT DOES:
+# 1. On PRs: Safely builds the Jupyter Book in a read-only context (safe for forks)
+#    and uploads the built HTML and PR metadata as artifacts for the
+#    "Deploy PR Preview" workflow to process later.
+# 2. On Pushes to main/master: Builds the Jupyter Book and directly deploys
+#    it to the production GitHub Pages environment.
+# ==============================================================================
 name: docs
 
 # Run this when the master or main branch changes, or on PRs to those branches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Documentation
+- Add JupyterBook build checks and live preview deployments to all pull requests [\#37](https://github.com/mlcast-community/mlcast-datasets/pull/37), @leifdenby
+
 ## [v0.2.0](https://github.com/mlcast-community/mlcast-datasets/releases/tag/v0.2.0) - 2026-03-17
 
 This release includes three new radar precipitation datasets from the UK, Denmark, and Italy, as well as several maintenance updates to ensure all datasets in the catalog pass validation checks and to fix some rendering issues in the documentation.


### PR DESCRIPTION
## Describe your changes

Alter ci workflow for jupyterbook build and deploy so that we always build the jupyter books, but only deploy when committing to main. Previously build only happened on commits to main, meaning that the CI didn't check that the notebooks succesfully executed before merging PRs

The motivation for this change is to ensure that all notebooks correctly execute before merging any PRs.

No change of dependencies required for this change.

## Issue Link

No issue created

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality, e.g. adding a new dataset)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected, e.g. removing or moving a dataset in the catalog)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
