### PR TITLE
Adding Météo-France radar precipitation dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release includes three new radar precipitation datasets from the UK, Denmar
 - UK Met Office C-band rain radar 1 km composite (2005-2025, 5min, OSGB 1 km) [\#17](https://github.com/mlcast-community/mlcast-datasets/issues/17), @franchg
 - Danish radar precipitation dataset covering 2016-2025 at 10min, 0.5km resolution, [\#21](https://github.com/mlcast-community/mlcast-datasets/pull/21), @arjj8
 - Italian DPC SRI radar precipitation dataset (2010-2025, 1km, 5min) [\#14](https://github.com/mlcast-community/mlcast-datasets/issues/14), @franchg
+- Météo-France radar precipitation dataset (from 2020-01-01 to 2024-12-31, 5min, 1km grid-size) [\#49](https://github.com/mlcast-community/mlcast-datasets/issues/49), @gzemo
 
 ### Maintenance
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -9,3 +9,4 @@ chapters:
 - file: it_dpc_precipitation
 - file: uk_metoffice_precipitation
 - file: be_rmi_precipitation
+- file: fr_mf_precipitation

--- a/docs/fr_mf_precipitation.ipynb
+++ b/docs/fr_mf_precipitation.ipynb
@@ -2,17 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "17a870aa",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# FR-MF - Rainfall rate over France mainland"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "933c22d2",
-   "metadata": {},
-   "source": [
+    "# FR-MF - Rainfall rate over France mainland\n",
+    "\n",
     "This notebook describes how to access and use the zarr-version of the French radar data provided by [Météo-France](https://donneespubliques.meteofrance.fr/). \n",
     "\n",
     "The dataset includes aproximately ~500.000 5 min timesteps covering a 1536 x 1536 resolution with 1km grid-size. The original .npz files are stored in (mm x 10^-2) and the .zarr dataset is in precipitation rate (mm/h).\n",
@@ -23,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d224ee6",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "889d8d26",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,34 +42,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66590d57",
+   "id": "3",
    "metadata": {},
    "source": [
-    "# FR-MF - 5-min Rainfall rate"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "41ffa405",
-   "metadata": {},
-   "source": [
+    "# FR-MF - 5-min Rainfall rate\n",
+    "\n",
     "The French MF SRI dataset is available in the intake catalog as `fr_mf_prate_5min`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "034cc54f",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = cat.precipitation.fr_mf_prate_5min.to_dask()"
+    "ds = cat.precipitation.fr_mf_prate_5min.to_dask()\n",
+    "ds"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d67ff03",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,15 +100,7 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
    "version": "3.12.3"
   }
  },

--- a/docs/fr_mf_precipitation.ipynb
+++ b/docs/fr_mf_precipitation.ipynb
@@ -59,7 +59,7 @@
    "id": "41ffa405",
    "metadata": {},
    "source": [
-    "The French MF SRI dataset is available in the intake catalog as [name_ds_on_catalog]()"
+    "The French MF SRI dataset is available in the intake catalog as `fr_mf_prate_5min`."
    ]
   },
   {
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = cat.fr_mf_prate_5min.to_dask()"
+    "ds = cat.precipitation.fr_mf_prate_5min.to_dask()"
    ]
   },
   {
@@ -106,7 +106,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "challenge-1 (3.12.3)",
+   "display_name": "mlcast-datasets (3.12.3)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/fr_mf_precipitation.ipynb
+++ b/docs/fr_mf_precipitation.ipynb
@@ -7,11 +7,34 @@
    "source": [
     "# FR-MF - Rainfall rate over France mainland\n",
     "\n",
-    "This notebook describes how to access and use the zarr-version of the French radar data provided by [Météo-France](https://donneespubliques.meteofrance.fr/). \n",
+    "### Description\n",
     "\n",
-    "The dataset includes aproximately ~500.000 5 min timesteps covering a 1536 x 1536 resolution with 1km grid-size. The original .npz files are stored in (mm x 10^-2) and the .zarr dataset is in precipitation rate (mm/h).\n",
+    "This notebook describes how to access and use the zarr-version of the French radar data provided by [Météo-France](https://meteofrance.com/). \n",
+    "The dataset includes aproximately ~500.000 5 min timesteps covering a 1536 x 1536 resolution with 1km grid-size. The original radar.npz files are stored in (mm x 10^-2) and the .zarr dataset is in precipitation rate (mm/h).\n",
     "\n",
-    "The `v0.1.0` zarr dataset covers the temporal period of `2020-01-01` to `2024-12-31`."
+    "### Related repositories\n",
+    "- The conversion of the radar data was done by the code hosted on [https://github.com/mlcast-community/mlcast-dataset-FR-MF](https://github.com/mlcast-community/mlcast-dataset-FR-MF).\n",
+    "\n",
+    "- The radar dataset can be directly downloaded from Météo-France [Hugging Face](https://huggingface.co/datasets/meteofrance/fr-radar-rainfall/tree/main) repository.\n",
+    "\n",
+    "The `v0.1.0` zarr dataset covers the temporal period of `2020-01-01` to `2024-12-31`.\n",
+    "\n",
+    "### Citation\n",
+    "\n",
+    "Data provided by Météo-France. Processed and distributed by Météo-France AI Lab for open research and development purposes.\n",
+    "Please cite as:\n",
+    "```tex\n",
+    "@misc{radar_rainfall_france,\n",
+    "  title        = {5 Minutes Radar Rainfall over French Mainland Territory},\n",
+    "  author       = {Météo-France},\n",
+    "  year         = {2025},\n",
+    "  howpublished = {\\url{https://huggingface.co/datasets/meteofrance/radar-rainfall}},\n",
+    "  note         = {Distributed under Etalab 2.0 License}\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Licence: [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)\n",
+    "\n"
    ]
   },
   {
@@ -87,9 +110,9 @@
     "    )\n",
     ")\n",
     "\n",
-    "for ax in g.axs.flat:\n",
+    "for ax in g.axes.flat:\n",
     "    ax.coastlines()\n",
-    "    ax.gridlines()"
+    "    ax.gridlines(draw_labels=[\"top\", \"left\"])"
    ]
   }
  ],
@@ -100,7 +123,15 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.12.3"
   }
  },

--- a/docs/fr_mf_precipitation.ipynb
+++ b/docs/fr_mf_precipitation.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "17a870aa",
+   "metadata": {},
+   "source": [
+    "# FR-MF - Rainfall rate over France mainland"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "933c22d2",
+   "metadata": {},
+   "source": [
+    "This notebook describes how to access and use the zarr-version of the French radar data provided by [Météo-France](https://donneespubliques.meteofrance.fr/). \n",
+    "\n",
+    "The dataset includes aproximately ~500.000 5 min timesteps covering a 1536 x 1536 resolution with 1km grid-size. The original .npz files are stored in (mm x 10^-2) and the .zarr dataset is in precipitation rate (mm/h).\n",
+    "\n",
+    "The `v0.1.0` zarr dataset covers the temporal period of `2020-01-01` to `2024-12-31`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d224ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import xarray as xr\n",
+    "\n",
+    "import cartopy.feature as cfeature\n",
+    "import cartopy.crs as ccrs\n",
+    "import mlcast_datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "889d8d26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat = mlcast_datasets.open_catalog()\n",
+    "list(cat.precipitation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66590d57",
+   "metadata": {},
+   "source": [
+    "# FR-MF - 5-min Rainfall rate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41ffa405",
+   "metadata": {},
+   "source": [
+    "The French MF SRI dataset is available in the intake catalog as [name_ds_on_catalog]()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "034cc54f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = cat.fr_mf_prate_5min.to_dask()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d67ff03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var_name = \"prate\"\n",
+    "crs_name = ds[var_name].grid_mapping\n",
+    "data_crs = ccrs.Projection(ds[crs_name].crs_wkt)\n",
+    "\n",
+    "g = (\n",
+    "    ds[var_name]\n",
+    "    .sel(time=\"2023-11-17\")\n",
+    "    .isel(time=slice(None, 3))\n",
+    "    .plot(\n",
+    "        transform=data_crs,\n",
+    "        cmap=\"viridis\",\n",
+    "        add_colorbar=True,\n",
+    "        col=\"time\",\n",
+    "        robust=True,\n",
+    "        subplot_kws=dict(projection=data_crs),\n",
+    "        vmin=0,\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "for ax in g.axs.flat:\n",
+    "    ax.coastlines()\n",
+    "    ax.gridlines()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "challenge-1 (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/mlcast_datasets/catalog/catalog.yml
+++ b/src/mlcast_datasets/catalog/catalog.yml
@@ -6,7 +6,7 @@ metadata:
 
 sources:
   precipitation:
-    description: "Precipitation-related datasets from RADKLIM, IT-DPC and other sources"
+    description: "Precipitation-related datasets from RADKLIM, IT-DPC, Météo-France and other sources"
     driver: intake.catalog.local.YAMLFileCatalog
     args:
       path: "{{ CATALOG_DIR }}/precipitation/catalog.yml"

--- a/src/mlcast_datasets/catalog/precipitation/catalog.yml
+++ b/src/mlcast_datasets/catalog/precipitation/catalog.yml
@@ -67,7 +67,7 @@ sources:
     description: "Météo-France 1 km radar rainfall amount dataset (mm*10^-2) converted in precipitation rate (mm/h)"
     driver: zarr
     args:
-      urlpath: "s3://mlcast-source-datasets/FR-MR-prate/v0.1.0/fr-mf-prate-5min.zarr/"
+      urlpath: "s3://mlcast-source-datasets/FR-MF-prate/v0.1.0/fr-mf-prate-5min.zarr/"
       consolidated: true
       storage_options:
         anon: true

--- a/src/mlcast_datasets/catalog/precipitation/catalog.yml
+++ b/src/mlcast_datasets/catalog/precipitation/catalog.yml
@@ -62,3 +62,13 @@ sources:
       storage_options:
         anon: true
         endpoint_url: "https://object-store.os-api.cci2.ecmwf.int"
+
+  fr_mf_prate_5min:
+    description: "Météo-France 1 km radar rainfall amount dataset (mm*10^-2) converted in precipitation rate (mm/h)"
+    driver: zarr
+    args:
+      urlpath: "s3://mlcast-source-datasets/FR-MR-prate/v0.1.0/fr-mf-prate-5min.zarr/"
+      consolidated: true
+      storage_options:
+        anon: true
+        endpoint_url: "https://object-store.os-api.cci2.ecmwf.int"


### PR DESCRIPTION
## Describe your changes

Pull request to start reviewing the addition of Météo-France Radar dataset (from 2020-01-01 to 2024-12-31, 5min, 1km grid-size).

The complete .zarr converted archive will be hosted on the ECMWF EWC S3 bucket. 

Conversion pipeline from raw .npz radar data to the stardardised (plus validated via the mlcast-validator) .zarr format will be shared in a dedicated mlcast-community repository. 


## Issue Link

Original [issue (#49)](https://github.com/mlcast-community/mlcast-datasets/issues/49).

## Type of change

- [ ] 📖 Documentation (Addition or improvements to documentation): 
 logs and .yaml configuration files updated by now. 

## Checklist before requesting a review

- [ ] Complete minor validator requests to build the definitive mlcast-compliant .zarr archive.
- [ ] Add conversion code in a mlcast-community repository. 
- [ ] Upload dataset to the object-storage.
